### PR TITLE
fix event duplication

### DIFF
--- a/src/EventStoreWorker.php
+++ b/src/EventStoreWorker.php
@@ -52,11 +52,11 @@ class EventStoreWorker extends Command
         $connection = $eventStore->connect(config('eventstore.tcp_url'));
         $streams = config('eventstore.streams');
 
-        $connection->subscribe(function () use ($eventStore, $streams) {
-            foreach ($streams as $stream) {
+        foreach ($streams as $stream) {
+            $connection->subscribe(function () use ($eventStore, $stream) {
                 $this->processStream($eventStore, $stream);
-            }
-        }, 'report');
+            }, 'report');
+        }
     }
 
     private function processStream($eventStore, string $stream)

--- a/src/EventStoreWorker.php
+++ b/src/EventStoreWorker.php
@@ -48,15 +48,16 @@ class EventStoreWorker extends Command
 
     public function processAllStreams()
     {
-        $eventStore = new EventStore();
-        $connection = $eventStore->connect(config('eventstore.tcp_url'));
         $streams = config('eventstore.streams');
 
-        $connection->subscribe(function () use ($eventStore, $streams) {
-            foreach ($streams as $stream) {
+        foreach ($streams as $stream) {
+            $eventStore = new EventStore();
+            $connection = $eventStore->connect(config('eventstore.tcp_url'));
+
+            $connection->subscribe(function () use ($eventStore, $stream) {
                 $this->processStream($eventStore, $stream);
-            }
-        }, 'report');
+            }, 'report');
+        }
     }
 
     private function processStream($eventStore, string $stream)


### PR DESCRIPTION
Apparently, if using one connection for multiple stream subscription the head of stream will not update correctly. Solution is to use different connection for each subscription