### PR TITLE
Copy more props to the data event record

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,10 @@
         "rxnet/eventstore-client": "^3.0.2"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
-        "phpunit/phpunit": "^8.0"
+        "morrislaptop/var-dumper-with-context": "^0.3.2",
+        "orchestra/testbench": "^4.2",
+        "phpunit/phpunit": "^8.0",
+        "timacdonald/log-fake": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/BasicLogger.php
+++ b/src/BasicLogger.php
@@ -11,7 +11,7 @@ class BasicLogger implements Logger
     public function eventStart($eventOrType, $payloadOrEvent)
     {
         $url = parse_url(config('eventstore.http_url'));
-        $url = "{$url['scheme']}://{$url['host']}:{$url['port']}";
+        $url = "{$url['scheme']}://{$url['host']}:{$url['port']}/web/index.html#";
 
         $type = $eventOrType;
         $event = $payloadOrEvent;

--- a/src/BasicLogger.php
+++ b/src/BasicLogger.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore;
+
+use DigitalRisks\LaravelEventStore\Contracts\Logger;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+
+class BasicLogger implements Logger
+{
+    public function eventStart($eventOrType, $payloadOrEvent)
+    {
+        $url = parse_url(config('eventstore.http_url'));
+        $url = "{$url['scheme']}://{$url['host']}:{$url['port']}";
+
+        $type = $eventOrType;
+        $event = $payloadOrEvent;
+
+        if (is_object($eventOrType)) {
+            $type = get_class($eventOrType);
+            $event = $eventOrType->getEventRecord();
+        }
+
+        $stream = $event->getStreamId();
+        $number = $event->getNumber();
+        $hasListeners = Event::hasListeners($type);
+
+        Log::info("{$url}/streams/{$stream}/{$number}", ['type' => $type, 'hasListeners' => $hasListeners]);
+    }
+}

--- a/src/Console/Commands/EventStoreWorker.php
+++ b/src/Console/Commands/EventStoreWorker.php
@@ -151,9 +151,12 @@ class EventStoreWorker extends Command
     {
         $data = new EventData();
 
+        $data->setEventStreamId($event->getStreamId());
+        $data->setEventNumber($event->getNumber());
+        $data->setEventId($event->getId());
         $data->setEventType($event->getType());
-        $data->setCreatedEpoch($event->getCreated()->getTimestamp() * 1000);
         $data->setData(json_encode($event->getData()));
+        $data->setCreatedEpoch($event->getCreated()->getTimestamp() * 1000);
         $data->setMetadata(json_encode($this->safeGetMetadata($event)));
 
         return new JsonEventRecord($data);

--- a/src/Contracts/Logger.php
+++ b/src/Contracts/Logger.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Contracts;
+
+use Ramsey\Uuid\UuidInterface;
+use Rxnet\EventStore\Record\EventRecord;
+
+interface Logger
+{
+    public function eventStart($event, $payload);
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace DigitalRisks\LaravelEventStore;
 
 use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorker;
+use DigitalRisks\LaravelEventStore\Contracts\Logger;
 use DigitalRisks\LaravelEventStore\Contracts\ShouldBeStored;
 use DigitalRisks\LaravelEventStore\Listeners\SendToEventStoreListener;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
@@ -15,6 +16,8 @@ class ServiceProvider extends LaravelServiceProvider
      */
     public function boot()
     {
+        $this->app->bind(Logger::class, BasicLogger::class);
+
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/eventstore.php' => config_path('eventstore.php'),

--- a/src/Tests/Traits/MakesEventRecords.php
+++ b/src/Tests/Traits/MakesEventRecords.php
@@ -8,12 +8,13 @@ use Rxnet\EventStore\Record\JsonEventRecord;
 
 trait MakesEventRecords
 {
-    public function makeEventRecord($type, $data, $metadata = [], $created = null)
+    public function makeEventRecord($type, $data, $metadata = [], $created = null, $stream = 'test-stream')
     {
         $event = new EventRecord();
         $created = new Carbon($created);
 
         $event->setEventType($type);
+        $event->setEventStreamId($stream);
         $event->setCreatedEpoch($created->getTimestamp() * 1000);
         $event->setData(json_encode($data));
         $event->setMetadata(json_encode($metadata));

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Tests;
+
+use DigitalRisks\LaravelEventStore\BasicLogger;
+use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
+use DigitalRisks\LaravelEventStore\Contracts\Logger;
+use DigitalRisks\LaravelEventStore\Contracts\ShouldBeStored;
+use DigitalRisks\LaravelEventStore\Tests\Fixtures\TestEvent;
+use DigitalRisks\LaravelEventStore\Tests\Traits\InteractsWithEventStore;
+use DigitalRisks\LaravelEventStore\Tests\Traits\MakesEventRecords;
+use DigitalRisks\LaravelEventStore\Traits\SendsToEventStore;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use TiMacDonald\Log\LogFake;
+
+class LoggerTest extends TestCase
+{
+    use MakesEventRecords;
+
+    /** @test */
+    public function it_logs_an_ignored_classed_event()
+    {
+        // Arrange.
+        Log::swap(new LogFake);
+
+        $event = new TestEvent();
+        $event->setEventRecord($this->makeEventRecord('test_event', ['hello' => 'world']));
+
+        // Act.
+        $logger = resolve(Logger::class);
+        $logger->eventStart($event, null);
+
+        // Assert.
+        Log::assertLogged('info', function ($msg, $context) {
+            $this->assertStringContainsString("/streams/test-stream/0", $msg);
+            $this->assertEquals(['type' => 'DigitalRisks\LaravelEventStore\Tests\Fixtures\TestEvent', 'hasListeners' => false], $context);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function it_logs_an_event()
+    {
+        // Arrange.
+        Log::swap(new LogFake);
+
+        $event = $this->makeEventRecord('test_event', ['hello' => 'world']);
+
+        // Act.
+        $logger = resolve(Logger::class);
+        $logger->eventStart($event->getType(), $event);
+
+        // Assert.
+        Log::assertLogged('info', function ($msg, $context) {
+            $this->assertStringContainsString("/streams/test-stream/0", $msg);
+            $this->assertEquals(['type' => 'test_event', 'hasListeners' => false], $context);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function it_logs_an_event_with_a_listener()
+    {
+        // Arrange.
+        Log::swap(new LogFake);
+
+        $event = $this->makeEventRecord('test_event', ['hello' => 'world']);
+        Event::listen('test_event', function () {});
+
+        // Act.
+        $logger = resolve(Logger::class);
+        $logger->eventStart($event->getType(), $event);
+
+        // Assert.
+        Log::assertLogged('info', function ($msg, $context) {
+            $this->assertStringContainsString("/streams/test-stream/0", $msg);
+            $this->assertEquals(['type' => 'test_event', 'hasListeners' => true], $context);
+
+            return true;
+        });
+    }
+}


### PR DESCRIPTION
* Move logging to a Logger class so others can easily change the logging mechanism if needed
* Include the event type and specify whether the event has listeners or not
* Dropped connection type as this should be known via the event vars

e.g. [2019-10-17 13:22:38] local.INFO: http://localhost:2113/streams/accounts-v13/20575 {"type":"account.chargebee_billing_activated","hasListeners":false}
