### PR TITLE
add connection attribute to allow for events to trigger listeners without going through ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ class AccountCreatedTest extends TestCase
 }
 ```
 
+
+
 ## Usage - Receiving Events
 
 You must first run the worker which will listen for events. 
@@ -257,6 +259,7 @@ class SendAccountCreatedEmail
 {
     public function handle(AccountCreated $event)
     {
+        // Side effect, let's only send an email when we've triggered this event and not when replaying events
         if (! $event->getEventRecord()) return;
 
         Mail::to($event->email)->send('Here is your account');
@@ -267,12 +270,17 @@ class SaveAccountToDatabase
 {
     public function handle(AccountCreated $event)
     {
+        // State change, let's ensure we update our database with this event.
         if ($event->getEventRecord()) return;
 
         Account::create(['email' => $event->email]);
     }
 }
 ```
+
+In addition, if you would like to test that are events are created AND how the application reacts to those events
+you may set `eventstore.connection` to `sync`. This will trick the event listeners into thinking that the
+event has been received from the eventstore.
 
 ### Testing
 
@@ -296,6 +304,8 @@ class QuoteStartedTest extends TestCase
     }
 }
 ```
+
+In addition you may set set `eventstore.connection` to `sync`, which will trick your listeners 
 
 ## Configuration
 

--- a/config/eventstore.php
+++ b/config/eventstore.php
@@ -6,4 +6,5 @@ return [
     'subscription_streams' => array_filter(explode(',', env('EVENTSTORE_SUBSCRIPTION_STREAMS'))),
     'volatile_streams' => array_filter(explode(',', env('EVENTSTORE_VOLATILE_STREAMS'))),
     'group' => env('EVENTSTORE_SUBSCRIPTION_GROUP', env('APP_NAME', 'laravel')),
+    'connection' => env('EVENTSTORE_CONNECTION'),
 ];

--- a/src/Traits/ReceivedFromEventStore.php
+++ b/src/Traits/ReceivedFromEventStore.php
@@ -2,11 +2,8 @@
 
 namespace DigitalRisks\LaravelEventStore\Traits;
 
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
-use ReflectionClass;
-use ReflectionProperty;
 use Rxnet\EventStore\Record\EventRecord;
+use Rxnet\EventStore\Data\EventRecord as EventRecordData;
 
 trait ReceivedFromEventStore
 {
@@ -14,6 +11,15 @@ trait ReceivedFromEventStore
 
     public function getEventRecord(): ?EventRecord
     {
+        if (config('eventstore.connection') == 'sync') {
+            $properties = get_object_vars($this);
+            unset($properties['event']);
+
+            return new EventRecord(new EventRecordData([
+                'data' => json_encode($properties)
+            ]));
+        }
+
         return $this->event;
     }
 

--- a/src/Traits/SendsToEventStore.php
+++ b/src/Traits/SendsToEventStore.php
@@ -6,6 +6,7 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use ReflectionClass;
 use ReflectionProperty;
+use Illuminate\Contracts\Support\Arrayable;
 
 trait SendsToEventStore
 {

--- a/tests/ReceivesEventTest.php
+++ b/tests/ReceivesEventTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Tests;
+
+use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
+use DigitalRisks\LaravelEventStore\Contracts\ShouldBeStored;
+use DigitalRisks\LaravelEventStore\Tests\Traits\InteractsWithEventStore;
+use DigitalRisks\LaravelEventStore\Traits\AddsLaravelMetadata;
+use DigitalRisks\LaravelEventStore\Traits\ReceivedFromEventStore;
+use DigitalRisks\LaravelEventStore\Traits\SendsToEventStore;
+
+class ReceivesEventTest extends TestCase
+{
+    use InteractsWithEventStore;
+
+    /** @test */
+    public function it_sets_the_event_record_on_received_event_when_event_connection_is_sync()
+    {
+        // Arrange.
+        config(['eventstore.connection' => 'sync']);
+
+        $event = new class implements CouldBeReceived {
+            use ReceivedFromEventStore;
+
+            public $hello = 'world';
+        };
+
+        // Act.
+        $record = $event->getEventRecord();
+
+        // Assert.
+        $this->assertEquals('world', $record->getData()['hello']);
+    }
+
+    /** @test */
+    public function it_sets_the_event_record_on_stored_event_when_event_connection_is_sync()
+    {
+        // Arrange.
+        config(['eventstore.connection' => 'sync']);
+        config(['app.name' => 'laravel-eventstore']);
+
+        $event = new class implements CouldBeReceived, ShouldBeStored {
+            use ReceivedFromEventStore, SendsToEventStore, AddsLaravelMetadata;
+
+            public $hello = 'world';
+
+            public function getData(): array {
+                return ['hello' => 'universe'];
+            }
+
+            public function getEventStream(): string {
+                return 'test';
+            }
+        };
+
+        // Act.
+        $record = $event->getEventRecord();
+
+        // Assert.
+        $this->assertEquals('universe', $record->getData()['hello']);
+        $this->assertEquals('laravel-eventstore', $record->getMetadata()['name']);
+    }
+
+    /** @test */
+    public function event_record_is_null_when_event_connection_is_not_sync()
+    {
+        // Arrange.
+        config(['eventstore.connection' => '']);
+
+        $event = new class implements CouldBeReceived {
+            use ReceivedFromEventStore;
+        };
+
+        // Act.
+        $record = $event->getEventRecord();
+
+        // Assert.
+        $this->assertNull($record);
+    }
+}


### PR DESCRIPTION
The concept for this to work can be shown here https://github.com/mannum/customer-portal-api/pull/22/files