### PR TITLE
split worker logic into threads

### DIFF
--- a/src/Console/Commands/EventStoreWorker.php
+++ b/src/Console/Commands/EventStoreWorker.php
@@ -7,8 +7,9 @@ use Symfony\Component\Process\Process;
 
 class EventStoreWorker extends Command
 {
+    // parallel > 1 can cause duplicate events
     protected $signature = 'eventstore:worker
-        {--parallel=10 : How many events to run in parallel.}';
+        {--parallel=1 : How many events to run in parallel.}';
 
     protected $description = 'Worker handling running stream processes';
 

--- a/src/Console/Commands/EventStoreWorker.php
+++ b/src/Console/Commands/EventStoreWorker.php
@@ -1,188 +1,49 @@
 <?php
 
 namespace DigitalRisks\LaravelEventStore\Console\Commands;
-
-use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
-use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
-use EventLoop\EventLoop;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Log;
-use ReflectionClass;
-use ReflectionProperty;
-use Rxnet\EventStore\Data\EventRecord as EventData;
-use Rxnet\EventStore\EventStore;
-use Rxnet\EventStore\Record\AcknowledgeableEventRecord;
-use Rxnet\EventStore\Record\EventRecord;
-use Rxnet\EventStore\Record\JsonEventRecord;
-use TypeError;
+use Symfony\Component\Process\Process;
 
 class EventStoreWorker extends Command
 {
-    protected $signature = 'eventstore:worker {--parallel= : How many events to run in parallel.} {--timeout= : How long the event should time out for.}';
+    protected $signature = 'eventstore:worker
+        {--parallel=10 : How many events to run in parallel.}';
 
-    protected $description = 'Worker handling incoming events from ES';
-
-    private $loop;
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->loop = EventLoop::getLoop();
-    }
+    protected $description = 'Worker handling running stream processes';
 
     public function handle(): void
     {
-        $timeout = $this->option('timeout') ?? 10;
+        $processes = [];
 
-        $this->loop->stop();
+        foreach (config('eventstore.subscription_streams') as $stream) {
+            if (empty($stream))
+                continue;
 
-        try {
-            $this->processAllStreams();
-            $this->loop->run();
-        } catch (\Exception $e) {
-            report($e);
+            $command = "php artisan eventstore:worker-thread --stream={$stream} --type=persistent --parallel={$this->option('parallel')}";
+            $process = Process::fromShellCommandline($command);
+            $process->start();
+
+            $processes[] = $process;
         }
 
-        $this->error('Lost connection with EventStore - reconnecting in ' . $timeout);
+        foreach (config('eventstore.volatile_streams') as $stream) {
+            if (empty($stream))
+                continue;
 
-        sleep($timeout);
+            $command = "php artisan eventstore:worker-thread --stream={$stream} --type=volatile --parallel={$this->option('parallel')}";
+            $process = Process::fromShellCommandline($command);
+            $process->start();
 
-        $this->handle();
-    }
-
-    private function processAllStreams(): void
-    {
-        $this->connectToStream(config('eventstore.subscription_streams'), function (EventStore $eventStore, string $stream) {
-            $this->processPersistentStream($eventStore, $stream);
-        });
-
-        $this->connectToStream(config('eventstore.volatile_streams'), function (EventStore $eventStore, string $stream) {
-            $this->processVolatileStream($eventStore, $stream);
-        });
-    }
-
-
-    private function connectToStream($streams, $callback): void
-    {
-        foreach ($streams as $stream) {
-            $eventStore = new EventStore();
-            $connection = $eventStore->connect(config('eventstore.tcp_url'));
-            $connection->subscribe(function () use ($eventStore, $stream, $callback) {
-                $callback($eventStore, $stream);
-            }, 'report');
+            $processes[] = $process;
         }
-    }
 
-    private function processPersistentStream($eventStore, string $stream): void
-    {
-        $eventStore
-            ->persistentSubscription($stream, config('eventstore.group'), $this->option('parallel') ?? 1)
-            ->subscribe(function (AcknowledgeableEventRecord $event) {
-                try {
-                    $this->dispatch($event);
-                    $event->ack();
-                } catch (\Exception $e) {
-                    $this->dumpEvent($event);
-                    $event->nack();
-                    report($e);
+        while(true) {
+            foreach($processes as $process)
+                if (!$process->isRunning()) {
+                    throw new \Exception("Process {$process->getCommandLine()} stopped running");
                 }
-            }, 'report');
-    }
 
-    private function processVolatileStream($eventStore, string $stream): void
-    {
-        $eventStore
-            ->volatileSubscription($stream)
-            ->subscribe(function (EventRecord $event) {
-                try {
-                    $this->dispatch($event);
-                } catch (\Exception $e) {
-                    $this->dumpEvent($event);
-                    report($e);
-                }
-            }, 'report');
-    }
-
-    protected function dumpEvent(EventRecord $event)
-    {
-        dump([
-            'id' => $event->getId(),
-            'number' => $event->getNumber(),
-            'stream' => $event->getStreamId(),
-            'type' => $event->getType(),
-            'created' => $event->getCreated(),
-            'data' => $event->getData(),
-            'metadata' => $this->safeGetMetadata($event),
-        ]);
-    }
-
-    protected function safeGetMetadata(EventRecord $event)
-    {
-        try {
-            return $event->getMetadata() ?? [];
-        } catch (TypeError $e) {
-            return [];
+            usleep(1000);
         }
-    }
-
-    public function dispatch(EventRecord $eventRecord): void
-    {
-        $logger = LaravelEventStore::$logger;
-        $serializedEvent = $payload = $this->makeSerializableEvent($eventRecord);
-        $event = $serializedEvent->getType();
-
-        if ($localEvent = $this->mapToLocalEvent($serializedEvent)) {
-            $event = $localEvent;
-            $payload = null;
-        }
-
-        $logger($serializedEvent, $event);
-        event($event, $payload);
-    }
-
-    private function makeSerializableEvent(EventRecord $event): JsonEventRecord
-    {
-        $data = new EventData();
-
-        $data->setEventId($event->getId());
-        $data->setEventType($event->getType());
-        $data->setEventNumber($event->getNumber());
-        $data->setData(json_encode($event->getData()));
-        $data->setEventStreamId($event->getStreamId());
-        $data->setMetadata(json_encode($this->safeGetMetadata($event)));
-        $data->setCreatedEpoch($event->getCreated()->getTimestamp() * 1000);
-
-
-        return new JsonEventRecord($data);
-    }
-
-    protected function mapToLocalEvent($event)
-    {
-        $eventToClass = LaravelEventStore::$eventToClass;
-        $className = $eventToClass ? $eventToClass($event) : 'App\Events\\' . $event->getType();
-
-        if (!class_exists($className)) {
-            return;
-        }
-
-        $reflection = new ReflectionClass($className);
-
-        if (!$reflection->implementsInterface(CouldBeReceived::class)) {
-            return;
-        }
-
-        $localEvent = new $className();
-        $props = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
-        $data = $event->getData();
-
-        foreach ($props as $prop) {
-            $key = $prop->getName();
-            $localEvent->$key = $data[$key] ?? null;
-        }
-
-        $localEvent->setEventRecord($event);
-
-        return $localEvent;
     }
 }

--- a/src/Console/Commands/EventStoreWorker.php
+++ b/src/Console/Commands/EventStoreWorker.php
@@ -7,9 +7,7 @@ use Symfony\Component\Process\Process;
 
 class EventStoreWorker extends Command
 {
-    // parallel > 1 can cause duplicate events
-    protected $signature = 'eventstore:worker
-        {--parallel=1 : How many events to run in parallel.}';
+    protected $signature = 'eventstore:worker';
 
     protected $description = 'Worker handling running stream processes';
 
@@ -19,7 +17,7 @@ class EventStoreWorker extends Command
             return null;
         }
 
-        $command = "php artisan eventstore:worker-thread --stream={$stream} --type={$type} --parallel={$this->option('parallel')}";
+        $command = "php artisan eventstore:worker-thread --stream={$stream} --type={$type}";
         $process = Process::fromShellCommandline($command);
         $process->start();
 

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -41,7 +41,7 @@ class EventStoreWorkerThread extends Command
 
         $this->loop->stop();
         try {
-            $this->processAllStreams();
+            $this->processStream();
             $this->loop->run();
         } catch (\Exception $e) {
             report($e);

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Console\Commands;
+use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
+use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
+use EventLoop\EventLoop;
+use Illuminate\Console\Command;
+use ReflectionClass;
+use ReflectionProperty;
+use Rxnet\EventStore\Data\EventRecord as EventData;
+use Rxnet\EventStore\EventStore;
+use Rxnet\EventStore\Record\AcknowledgeableEventRecord;
+use Rxnet\EventStore\Record\EventRecord;
+use Rxnet\EventStore\Record\JsonEventRecord;
+use TypeError;
+
+class EventStoreWorkerThread extends Command
+{
+    protected $signature = 'eventstore:worker-thread
+        {--stream= : Name of the stream to run on}
+        {--type=persistent : Type of stream (persistent / volatile)}
+        {--parallel=10 : How many events to run in parallel.}';
+
+    protected $description = 'Worker handling incoming event streams from ES';
+
+    public function handle(): void
+    {
+        if (!$this->option('stream')) {
+            $this->info("Stream option is required");
+            return;
+        }
+
+        $this->processStream();
+
+        \EventLoop\EventLoop::getLoop()->run();
+    }
+    private function connect($callback): void
+    {
+        $eventStore = new EventStore();
+        $eventStore->connect(config('eventstore.tcp_url'))
+            ->subscribe(function () use ($callback, $eventStore) {
+                $callback($eventStore);
+        }, 'report');
+    }
+
+    private function processStream(): void
+    {
+        $this->connect(function($eventStore){
+            if ($this->option('type') == 'volatile')
+                $this->processVolatileStream($eventStore, $this->option('stream'));
+
+            if ($this->option('type') == 'persistent')
+                $this->processPersistentStream($eventStore, $this->option('stream'));
+        });
+    }
+
+    private function processPersistentStream(EventStore $eventStore, string $stream): void
+    {
+        $eventStore->persistentSubscription($stream, config('eventstore.group'), $this->option('parallel') ?? 1)
+            ->subscribe(function (AcknowledgeableEventRecord $event) {
+                try {
+                    $this->dispatch($event);
+
+                    return $event->ack();
+                } catch (\Exception $e) {
+                    report($e);
+
+                    return $event->nack($event::NACK_ACTION_PARK);
+                }
+            });
+    }
+
+    private function processVolatileStream(EventStore $eventStore, string $stream): void
+    {
+        $eventStore->volatileSubscription($stream)
+            ->subscribe(function (EventRecord $event) {
+                try {
+                    $this->dispatch($event);
+                } catch (\Exception $e) {
+                    $this->dumpEvent($event);
+                    report($e);
+                }
+            }, 'report');
+    }
+
+    protected function safeGetMetadata(EventRecord $event)
+    {
+        try {
+            return $event->getMetadata() ?? [];
+        } catch (TypeError $e) {
+            return [];
+        }
+    }
+
+    public function dispatch(EventRecord $eventRecord): void
+    {
+        $logger = LaravelEventStore::$logger;
+        $serializedEvent = $payload = $this->makeSerializableEvent($eventRecord);
+        $event = $serializedEvent->getType();
+
+        if ($localEvent = $this->mapToLocalEvent($serializedEvent)) {
+            $event = $localEvent;
+            $payload = null;
+        }
+
+        $logger($serializedEvent, $event);
+        event($event, $payload);
+    }
+
+    private function makeSerializableEvent(EventRecord $event): JsonEventRecord
+    {
+        $data = new EventData();
+
+        $data->setEventId($event->getId());
+        $data->setEventType($event->getType());
+        $data->setEventNumber($event->getNumber());
+        $data->setData(json_encode($event->getData()));
+        $data->setEventStreamId($event->getStreamId());
+        $data->setMetadata(json_encode($this->safeGetMetadata($event)));
+        $data->setCreatedEpoch($event->getCreated()->getTimestamp() * 1000);
+
+        return new JsonEventRecord($data);
+    }
+
+    protected function mapToLocalEvent($event)
+    {
+        $eventToClass = LaravelEventStore::$eventToClass;
+        $className = $eventToClass ? $eventToClass($event) : 'App\Events\\' . $event->getType();
+
+        if (!class_exists($className)) {
+            return;
+        }
+
+        $reflection = new ReflectionClass($className);
+
+        if (!$reflection->implementsInterface(CouldBeReceived::class)) {
+            return;
+        }
+
+        $localEvent = new $className();
+        $props = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+        $data = $event->getData();
+
+        foreach ($props as $prop) {
+            $key = $prop->getName();
+            $localEvent->$key = $data[$key] ?? null;
+        }
+
+        $localEvent->setEventRecord($event);
+
+        return $localEvent;
+    }
+}

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -17,11 +17,9 @@ use TypeError;
 
 class EventStoreWorkerThread extends Command
 {
-    // parallel > 1 can cause duplicate events
     protected $signature = 'eventstore:worker-thread
         {--stream= : Name of the stream to run on}
-        {--type=persistent : Type of stream (persistent / volatile)}
-        {--parallel=10 : How many events to run in parallel.}';
+        {--type=persistent : Type of stream (persistent / volatile)}';
 
     protected $description = 'Worker handling incoming event streams from ES';
 
@@ -79,7 +77,7 @@ class EventStoreWorkerThread extends Command
 
     private function processPersistentStream(EventStore $eventStore, string $stream): void
     {
-        $eventStore->persistentSubscription($stream, config('eventstore.group'), $this->option('parallel') ?? 1)
+        $eventStore->persistentSubscription($stream, config('eventstore.group'))
             ->subscribe(function (AcknowledgeableEventRecord $event) {
                 try {
                     $this->dispatch($event);

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace DigitalRisks\LaravelEventStore\Console\Commands;
+
 use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
 use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
 use EventLoop\EventLoop;
@@ -48,7 +49,7 @@ class EventStoreWorkerThread extends Command
         }
 
         $this->error('Lost connection with EventStore - reconnecting');
-        usleep(1000);
+        sleep(1);
 
         $this->handle();
     }
@@ -59,17 +60,19 @@ class EventStoreWorkerThread extends Command
         $eventStore->connect(config('eventstore.tcp_url'))
             ->subscribe(function () use ($callback, $eventStore) {
                 $callback($eventStore);
-        }, 'report');
+            }, 'report');
     }
 
     private function processStream(): void
     {
-        $this->connect(function($eventStore){
-            if ($this->option('type') == 'volatile')
+        $this->connect(function ($eventStore) {
+            if ($this->option('type') == 'volatile') {
                 $this->processVolatileStream($eventStore, $this->option('stream'));
+            }
 
-            if ($this->option('type') == 'persistent')
+            if ($this->option('type') == 'persistent') {
                 $this->processPersistentStream($eventStore, $this->option('stream'));
+            }
         });
     }
 

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -17,6 +17,7 @@ use TypeError;
 
 class EventStoreWorkerThread extends Command
 {
+    // parallel > 1 can cause duplicate events
     protected $signature = 'eventstore:worker-thread
         {--stream= : Name of the stream to run on}
         {--type=persistent : Type of stream (persistent / volatile)}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace DigitalRisks\LaravelEventStore;
 
 use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreReset;
 use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorker;
+use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorkerThread;
 use DigitalRisks\LaravelEventStore\Contracts\ShouldBeStored;
 use DigitalRisks\LaravelEventStore\EventStore;
 use DigitalRisks\LaravelEventStore\Listeners\SendToEventStoreListener;
@@ -24,6 +25,7 @@ class ServiceProvider extends LaravelServiceProvider
 
             $this->commands([
                 EventStoreWorker::class,
+                EventStoreWorkerThread::class,
                 EventStoreReset::class,
             ]);
         }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -2,9 +2,7 @@
 
 namespace DigitalRisks\LaravelEventStore\Tests;
 
-use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorker;
-use DigitalRisks\LaravelEventStore\EventStore;
-use DigitalRisks\LaravelEventStore\Tests\Fixtures\TestEvent;
+use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorkerThread;
 use DigitalRisks\LaravelEventStore\Tests\Traits\MakesEventRecords;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
@@ -19,7 +17,7 @@ class LoggerTest extends TestCase
         // Arrange.
         Log::swap(new LogFake);
 
-        $worker = resolve(EventStoreWorker::class);
+        $worker = resolve(EventStoreWorkerThread::class);
         $event = $this->makeEventRecord('test_event', ['hello' => 'world']);
 
         // Act.
@@ -39,7 +37,7 @@ class LoggerTest extends TestCase
         // Arrange.
         Log::swap(new LogFake);
 
-        $worker = resolve(EventStoreWorker::class);
+        $worker = resolve(EventStoreWorkerThread::class);
         $event = $this->makeEventRecord('test_event', ['hello' => 'world']);
         Event::listen('test_event', function () {
         });

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -2,7 +2,7 @@
 
 namespace DigitalRisks\LaravelEventStore\Tests;
 
-use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorker;
+use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorkerThread;
 use DigitalRisks\LaravelEventStore\EventStore;
 use DigitalRisks\LaravelEventStore\Tests\Fixtures\TestEvent;
 use DigitalRisks\LaravelEventStore\Tests\Traits\InteractsWithEventStore;
@@ -18,7 +18,7 @@ class WorkerTest extends TestCase
     {
         // Arrange.
         Event::fake();
-        $worker = resolve(EventStoreWorker::class);
+        $worker = resolve(EventStoreWorkerThread::class);
         $event = $this->makeEventRecord('event_with_no_class', ['hello' => 'world']);
 
         // Act.
@@ -36,7 +36,7 @@ class WorkerTest extends TestCase
     {
         // Arrange.
         Event::fake();
-        $worker = resolve(EventStoreWorker::class);
+        $worker = resolve(EventStoreWorkerThread::class);
         $event = $this->makeEventRecord('test_event', ['hello' => 'world']);
 
         EventStore::eventToClass(function ($event) {
@@ -58,7 +58,7 @@ class WorkerTest extends TestCase
     {
         // Arrange.
         Event::fake();
-        $worker = resolve(EventStoreWorker::class);
+        $worker = resolve(EventStoreWorkerThread::class);
         $event = $this->makeEventRecord('test_event', ['hello' => 'world'], null);
 
         // Act.


### PR DESCRIPTION
Having fought with the issues for quite some time I think this is the solution. Bear in mind, that the only thing that I'm certain is that there needs to be return ack / nack in subscribe Observable to inform ES. I don't know when it was removed, but that takes part in some of the problems (with speeds of event processing) we're having; currently it still works, because ES knows about which events were processed and which weren't, but there's a significant performance loss without these returns. Now, for other issue of head not updating / additional performance issues - please take the below as my assumptions as to how rxnet implementation of ES works and why we need separate threads for EventLoop (EL) (it was a lengthy ride)

I believe that each event on ES consists of multiple actions that are put on the same "queue" (which is EL). As such there're actions like: SubscriptionDropped, PersistentSubscriptionConfirmation, PersistentSubscriptionStreamEventAppeared etc. - all of them are Observables. Additionally there're writer/reader classes that work on that connection, embedded within ES class (reader is a buffer for TCP packets retrieved from ES - there's assembly of event data from multiple packets I've fixed some time ago in rxnet library, but I don't know if that feeds into actions; writer sends commands to ES). So, we have loop that runs through actions that arrive and go out to ES

If we use one connection for multiple streams, there's a slowdown in how events are processed (which kind of makes sense, as every time you switch streams actions need to be performed to get current head, retrieve event, send ack to advance the head - this is due to usage of one reader/writer in rxnet EventStore class). The solution would then to use, for each stream a separate EventStore object (which I was already doing) - this means that each streams gets its own reader/writer, and that removes overhead of stream switching. Now enter parallelisation - in this context this means "how many events should be accessed at a time" (they're still accessed synchronously - I don't know what "at a time" means, as parallelisation gives idea of events arriving in EL in any order, let's say 10 at a time, but I'm always getting them in correct order). There's also mystery of difference in quality of subscriptions - first subscription will always be processed faultlessly; second will sometimes run at the same speeds as first; third and fourth will usually stutter and not process through events as quickly; parallelisation seemed to fix that.

To gain a significant performance boost as little as setting of 10 can be used. With one connection that means that 10 events for each stream would be processed in round robin. With separate connections that means that 10 events would be retrieved for each stream and then would be processed in fifo. I've proceeded to test out the latter option. Looking at the logs I would still notice issue where one stream would stop because of the other, or one stream would jump back, to anothers head (for example - quotes was at 3k, accounts was at 2.5k, quotes would go back to 2.5k and start processing from there). Both of the cases happened sporadically, but got me thinking that they're caused by same thing - action of head lookup arrives in EL, gets picked up by wrong subscription, causes stream processing to stop (because stream caught up to head) or reruns already processed events.

As there's no way to create multiple EL and there's no other ES library, I've as such separated each stream into separate PHP thread, kept one worker and maintained current behaviour.