### PR TITLE
fix logging

### DIFF
--- a/src/Console/Commands/EventStoreWorker.php
+++ b/src/Console/Commands/EventStoreWorker.php
@@ -3,7 +3,6 @@
 namespace DigitalRisks\LaravelEventStore\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
 use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
 
@@ -71,18 +70,7 @@ class EventStoreWorker extends Command
                         $line = trim($line);
 
                         if (!empty($line)) {
-                            (LaravelEventStore::$infoLogger)($line);
-                        }
-                    }
-                }
-
-                $error = $entry['process']->getIncrementalErrorOutput();
-                if (!empty($error)) {
-                    foreach (explode(PHP_EOL, $error) as $line) {
-                        $line = trim($line);
-
-                        if (!empty($line)) {
-                            (LaravelEventStore::$errorLogger)($line);
+                            (LaravelEventStore::$workerLogger)($line);
                         }
                     }
                 }

--- a/src/Console/Commands/EventStoreWorker.php
+++ b/src/Console/Commands/EventStoreWorker.php
@@ -3,7 +3,9 @@
 namespace DigitalRisks\LaravelEventStore\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
+use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
 
 class EventStoreWorker extends Command
 {
@@ -60,6 +62,28 @@ class EventStoreWorker extends Command
                             'stream' => $entry['stream'],
                             'type' => $entry['type']
                         ];
+                    }
+                }
+
+                $output = $entry['process']->getIncrementalOutput();
+                if (!empty($output)) {
+                    foreach (explode(PHP_EOL, $output) as $line) {
+                        $line = trim($line);
+
+                        if (!empty($line)) {
+                            (LaravelEventStore::$infoLogger)($line);
+                        }
+                    }
+                }
+
+                $error = $entry['process']->getIncrementalErrorOutput();
+                if (!empty($error)) {
+                    foreach (explode(PHP_EOL, $error) as $line) {
+                        $line = trim($line);
+
+                        if (!empty($line)) {
+                            (LaravelEventStore::$errorLogger)($line);
+                        }
                     }
                 }
             }

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -36,7 +36,7 @@ class EventStoreWorkerThread extends Command
     public function handle(): void
     {
         if (!$this->option('stream')) {
-            report("Stream option is required");
+            report(new \Exception('Stream option is required'));
             return;
         }
 
@@ -48,7 +48,7 @@ class EventStoreWorkerThread extends Command
             report($e);
         }
 
-        report('Lost connection with EventStore - reconnecting');
+        report(new \Exception('Lost connection with EventStore - reconnecting'));
         sleep(1);
 
         $this->handle();

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -129,11 +129,11 @@ class EventStoreWorkerThread extends Command
         $type = $serializedEvent->getType();
         $stream = $serializedEvent->getStreamId();
         $number = $serializedEvent->getNumber();
+
         $hasListener = Event::hasListeners($type);
+        $metadata = ['type' => $event, 'hasListeners' => $hasListener];
 
-        $metadata = json_encode(['type' => $event, 'hasListeners' => $hasListener]);
-
-        (LaravelEventStore::$threadLogger)("{$url}/streams/{$stream}/{$number} {$metadata}");
+        (LaravelEventStore::$threadLogger)("{$url}/streams/{$stream}/{$number}", $metadata);
         event($event, $payload);
     }
 

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -36,7 +36,7 @@ class EventStoreWorkerThread extends Command
     public function handle(): void
     {
         if (!$this->option('stream')) {
-            $this->info("Stream option is required");
+            report("Stream option is required");
             return;
         }
 
@@ -48,7 +48,7 @@ class EventStoreWorkerThread extends Command
             report($e);
         }
 
-        $this->error('Lost connection with EventStore - reconnecting');
+        report('Lost connection with EventStore - reconnecting');
         sleep(1);
 
         $this->handle();
@@ -133,7 +133,7 @@ class EventStoreWorkerThread extends Command
 
         $metadata = json_encode(['type' => $event, 'hasListeners' => $hasListener]);
 
-        $this->info("{$url}/streams/{$stream}/{$number} {$metadata}");
+        (LaravelEventStore::$threadLogger)("{$url}/streams/{$stream}/{$number} {$metadata}");
         event($event, $payload);
     }
 

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -14,6 +14,7 @@ use Rxnet\EventStore\Record\AcknowledgeableEventRecord;
 use Rxnet\EventStore\Record\EventRecord;
 use Rxnet\EventStore\Record\JsonEventRecord;
 use TypeError;
+use Illuminate\Support\Facades\Event;
 
 class EventStoreWorkerThread extends Command
 {
@@ -115,7 +116,6 @@ class EventStoreWorkerThread extends Command
 
     public function dispatch(EventRecord $eventRecord): void
     {
-        $logger = LaravelEventStore::$logger;
         $serializedEvent = $payload = $this->makeSerializableEvent($eventRecord);
         $event = $serializedEvent->getType();
 
@@ -124,7 +124,16 @@ class EventStoreWorkerThread extends Command
             $payload = null;
         }
 
-        $logger($serializedEvent, $event);
+        $url = parse_url(config('eventstore.http_url'));
+        $url = "{$url['scheme']}://{$url['host']}:{$url['port']}/web/index.html#";
+        $type = $serializedEvent->getType();
+        $stream = $serializedEvent->getStreamId();
+        $number = $serializedEvent->getNumber();
+        $hasListener = Event::hasListeners($type);
+
+        $metadata = json_encode(['type' => $event, 'hasListeners' => $hasListener]);
+
+        $this->info("{$url}/streams/{$stream}/{$number} {$metadata}");
         event($event, $payload);
     }
 

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -3,7 +3,6 @@
 namespace DigitalRisks\LaravelEventStore;
 
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Event;
 
 class EventStore
 {
@@ -19,7 +18,9 @@ class EventStore
      *
      * @var callable
      */
-    public static $logger;
+    public static $infoLogger;
+
+    public static $errorLogger;
 
     /**
      * Set the event class based on current event key.
@@ -42,19 +43,17 @@ class EventStore
      * @param callable $callback
      * @return void
      */
-    public static function logger(?callable $callback = null)
+    public static function logger(?callable $infoCallback = null, ?callable $errorCallback = null)
     {
-        $callback = $callback ?: function ($event, $type) {
-            $url = parse_url(config('eventstore.http_url'));
-            $url = "{$url['scheme']}://{$url['host']}:{$url['port']}/web/index.html#";
-            $type = $event->getType();
-            $stream = $event->getStreamId();
-            $number = $event->getNumber();
-            $hasListener = Event::hasListeners($type);
-
-            Log::info("{$url}/streams/{$stream}/{$number}", ['type' => $type, 'hasListeners' => $hasListener]);
+        $infoCallback = $infoCallback ?: function($message){
+            return Log::info($message);
         };
 
-        static::$logger = $callback;
+        $errorCallback = $errorCallback ?: function($message){
+            return Log::error($message);
+        };
+
+        static::$infoLogger = $infoCallback;
+        static::$errorLogger = $errorCallback;
     }
 }

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -75,10 +75,13 @@ class EventStore
             if (empty($channels['stdout'])) {
                 $channels['stdout'] = [
                     'driver' => 'monolog',
-                    'handler' => 'Monolog\Handler\StreamHandler',
-                    'formatter' => null,
+                    'handler' => \Monolog\Handler\StreamHandler::class,
+                    'formatter' => \Monolog\Formatter\LineFormatter::class,
+                    'formatter_with' => [
+                        'format' => "%message%",
+                    ],
                     'with' => [
-                        'stream' => 'php://stdout'
+                        'stream' => 'php://stdout',
                     ]
                 ];
 

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -51,8 +51,8 @@ class EventStore
      */
     public static function workerLogger(?callable $logger = null)
     {
-        static::$workerLogger = $logger ?: function($message){
-            Log::info($message);
+        static::$workerLogger = $logger ?: function($message, $context){
+            Log::info($message, $context);
         };
     }
 
@@ -64,8 +64,8 @@ class EventStore
      */
     public static function threadLogger(?callable $logger = null)
     {
-        static::$threadLogger = $logger ?: function($message){
-            Log::channel('stdout')->info($message);
+        static::$threadLogger = $logger ?: function($message, $context){
+            Log::channel('stdout')->info($message, $context);
         };
 
         // setup stdout channel
@@ -78,7 +78,7 @@ class EventStore
                     'handler' => \Monolog\Handler\StreamHandler::class,
                     'formatter' => \Monolog\Formatter\LineFormatter::class,
                     'formatter_with' => [
-                        'format' => "%message%",
+                        'format' => "%message% %context%",
                     ],
                     'with' => [
                         'stream' => 'php://stdout',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -31,7 +31,8 @@ class ServiceProvider extends LaravelServiceProvider
         }
 
         $this->eventClasses();
-        $this->logger();
+        $this->threadLogger();
+        $this->workerLogger();
 
         Event::listen(ShouldBeStored::class, SendToEventStoreListener::class);
     }
@@ -43,7 +44,8 @@ class ServiceProvider extends LaravelServiceProvider
      */
     public function eventClasses()
     {
-        EventStore::eventToClass();
+        if (empty(EventStore::$eventToClass))
+            EventStore::eventToClass();
     }
 
     /**
@@ -51,9 +53,21 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function logger()
+    public function threadLogger($logger = null)
     {
-        EventStore::logger();
+        if (empty(EventStore::$threadLogger))
+            EventStore::threadLogger($logger);
+    }
+
+    /**
+     * Handle logging when event is triggered.
+     *
+     * @return void
+     */
+    public function workerLogger($logger = null)
+    {
+        if (empty(EventStore::$workerLogger))
+            EventStore::workerLogger($logger);
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -42,10 +42,10 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function eventClasses()
+    public function eventClasses(?callable $callback = null)
     {
         if (empty(EventStore::$eventToClass))
-            EventStore::eventToClass();
+            EventStore::eventToClass($callback);
     }
 
     /**
@@ -53,7 +53,7 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function threadLogger($logger = null)
+    public function threadLogger(?callable $logger = null)
     {
         if (empty(EventStore::$threadLogger))
             EventStore::threadLogger($logger);
@@ -64,7 +64,7 @@ class ServiceProvider extends LaravelServiceProvider
      *
      * @return void
      */
-    public function workerLogger($logger = null)
+    public function workerLogger(?callable $logger = null)
     {
         if (empty(EventStore::$workerLogger))
             EventStore::workerLogger($logger);

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -24,9 +24,9 @@ class LoggerTest extends TestCase
         $worker->dispatch($event);
 
         // Assert.
-        Log::assertLogged('info', function ($message, $context) {
+        Log::assertLogged('info', function ($message) {
             $this->assertStringContainsString("/streams/test-stream/0", $message);
-            $this->assertEquals(['type' => 'test_event', 'hasListeners' => false], $context);
+            $this->assertStringContainsString(json_encode(['type' => 'test_event', 'hasListeners' => false]), $message);
 
             return true;
         });
@@ -46,9 +46,9 @@ class LoggerTest extends TestCase
         $worker->dispatch($event);
 
         // Assert.
-        Log::assertLogged('info', function ($message, $context) {
+        Log::assertLogged('info', function ($message) {
             $this->assertStringContainsString("/streams/test-stream/0", $message);
-            $this->assertEquals(['type' => 'test_event', 'hasListeners' => true], $context);
+            $this->assertStringContainsString(json_encode(['type' => 'test_event', 'hasListeners' => true]), $message);
 
             return true;
         });

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -24,9 +24,9 @@ class LoggerTest extends TestCase
         $worker->dispatch($event);
 
         // Assert.
-        Log::assertLogged('info', function ($message) {
+        Log::assertLogged('info', function ($message, $context) {
             $this->assertStringContainsString("/streams/test-stream/0", $message);
-            $this->assertStringContainsString(json_encode(['type' => 'test_event', 'hasListeners' => false]), $message);
+            $this->assertEquals(['type' => 'test_event', 'hasListeners' => false], $context);
 
             return true;
         });
@@ -46,9 +46,9 @@ class LoggerTest extends TestCase
         $worker->dispatch($event);
 
         // Assert.
-        Log::assertLogged('info', function ($message) {
+        Log::assertLogged('info', function ($message, $context) {
             $this->assertStringContainsString("/streams/test-stream/0", $message);
-            $this->assertStringContainsString(json_encode(['type' => 'test_event', 'hasListeners' => true]), $message);
+            $this->assertEquals(['type' => 'test_event', 'hasListeners' => true], $context);
 
             return true;
         });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         EventStore::eventToClass();
-        EventStore::threadLogger(function($message){ return Log::info($message); });
+        EventStore::threadLogger(function($message, $context){ return Log::info($message, $context); });
 
         return [
             ServiceProvider::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,13 +5,14 @@ namespace DigitalRisks\LaravelEventStore\Tests;
 use DigitalRisks\LaravelEventStore\EventStore;
 use DigitalRisks\LaravelEventStore\ServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Illuminate\Support\Facades\Log;
 
 class TestCase extends Orchestra
 {
     protected function getPackageProviders($app)
     {
         EventStore::eventToClass();
-        EventStore::logger();
+        EventStore::threadLogger(function($message){ return Log::info($message); });
 
         return [
             ServiceProvider::class,


### PR DESCRIPTION
Following #26 I've noticed that logging is no longer working due to it not being fed to console in main thread. We've two choices - either change that the main logger is `Log::info('papertrail')` (don't know how much work is there in setting that up, or if that even would work - @morrislaptop can you comment on this please), or feed the output of one command into another, which this PR does.

I'm introducing here two methods - `threadLogger` (used to log what is happening in thread) and `workerLogger` (used to log what is happening in worker) instead of previous `logger` method (used to log an event). Report method is still used to track exceptions / errors. I'm also introducing `stdout` channel - I could use native `stderr` and `getIncrementalErrorOutput` instead of `getIncrementalOutput` but that seemed ugly. Please comment if you've got a way to set channels in a more sensible way - I'm not entirely happy with how it's done here

There's also a small fix in provider to set `threadLogger` if it's not defined already (which happens in `TestCase:: getPackageProviders `) - without it provider always resets the loggers to default.