### PR TITLE
February housekeeping

### DIFF
--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -89,7 +89,7 @@ class EventStoreWorkerThread extends Command
 
                     return $event->nack($event::NACK_ACTION_PARK);
                 }
-            });
+            }, 'report');
     }
 
     private function processVolatileStream(EventStore $eventStore, string $stream): void

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -99,7 +99,6 @@ class EventStoreWorkerThread extends Command
                 try {
                     $this->dispatch($event);
                 } catch (\Exception $e) {
-                    $this->dumpEvent($event);
                     report($e);
                 }
             }, 'report');


### PR DESCRIPTION
The intent behind this PR is to:
- clean up call to no longer declared `dumpEvent` method
- use report in all `subscribe` methods
- make `dispatch` logic clearer