### PR TITLE
Feat: Add replay command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-EVENTSTORE_URL=tcp://admin:changeit@localhost:1113
-EVENTSTORE_WEB_URL=http://localhost:2113
+EVENTSTORE_TCP_URL=tcp://admin:changeit@localhost:1113
+EVENTSTORE_HTTP_URL=http://localhost:2113
 
 EVENTSTORE_STREAMS_ACCOUNTS=accounts-v13
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ You can replay events by using the replay command
 php artisan eventstore:replay <stream> <event>
 ````
 
-`<event>` can be a single event number of a range like `390-396`
+`<event>` can be a single event number or a range like `390-396`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,16 @@ class QuoteStartedTest extends TestCase
 
 In addition you may set set `eventstore.connection` to `sync`, which will trick your listeners 
 
+## Usage - Replaying Events
+
+You can replay events by using the replay command
+
+````
+php artisan eventstore:replay <stream> <event>
+````
+
+`<event>` can be a single event number of a range like `390-396`
+
 ## Configuration
 
 The defaults are set in `config/eventstore.php`. Copy this file to your own config directory to modify the values:

--- a/src/Console/Commands/EventStoreReplay.php
+++ b/src/Console/Commands/EventStoreReplay.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Console\Commands;
+
+use DigitalRisks\LaravelEventStore\Client;
+use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
+use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
+use Illuminate\Console\Command;
+use ReflectionClass;
+use ReflectionProperty;
+use Illuminate\Support\Facades\Event;
+use Rxnet\EventStore\Data\EventRecord as EventData;
+use Rxnet\EventStore\Record\JsonEventRecord;
+
+class EventStoreReplay extends Command
+{
+    protected $signature = 'eventstore:replay {stream} {events}';
+
+    protected $description = 'Replay a single or range of events';
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $stream = $this->argument('stream');
+        $events = explode('-', $this->argument('events'));
+
+        if (count($events) > 1) {
+            $events = range($events[0], $events[1]);
+        }
+
+        $progressBar = $this->output->createProgressBar(count($events));
+        $progressBar->start();
+
+        foreach ($events as $key => $event) {
+            $response = $this->client->get("/streams/$stream/$event", [
+                'headers' => [
+                    'Accept' => 'application/vnd.eventstore.atom+json'
+                ]
+            ]);
+
+            $eventData = json_decode($response->getBody()->getContents(), true);
+
+            try {
+                $this->dispatch($eventData);
+                $progressBar->advance();
+            } catch (\Exception $e) {
+                $this->info("Error: " . $e->getMessage());
+                report($e);
+            }
+        }
+
+        $progressBar->finish();
+    }
+
+    public function dispatch(array $eventData): void
+    {
+        $serializedEvent = $this->makeSerializableEvent($eventData);
+
+        $type = $serializedEvent->getType();
+        
+        if ($localEvent = $this->mapToLocalEvent($serializedEvent)) {
+            $event = $localEvent;
+            $payload = null;
+        } else {
+            $event = $type;
+            $payload = $serializedEvent;
+        }
+
+        event($event, $payload);
+    }
+
+    protected function mapToLocalEvent($event)
+    {
+        $eventToClass = LaravelEventStore::$eventToClass;
+        $className = $eventToClass ? $eventToClass($event) : 'App\Events\\' . $event->getType();
+
+        if (!class_exists($className)) {
+            return;
+        }
+
+        $reflection = new ReflectionClass($className);
+
+        if (!$reflection->implementsInterface(CouldBeReceived::class)) {
+            return;
+        }
+
+        $localEvent = new $className();
+        $props = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+        $data = $event->getData();
+
+        foreach ($props as $prop) {
+            $key = $prop->getName();
+            $localEvent->$key = $data[$key] ?? null;
+        }
+
+        $localEvent->setEventRecord($event);
+
+        return $localEvent;
+    }
+
+    private function makeSerializableEvent(array $event): JsonEventRecord
+    {
+        $data = new EventData();
+        $data->setEventId($event['content']['eventId']);
+        $data->setEventType($event['content']['eventType']);
+        $data->setEventNumber($event['content']['eventNumber']);
+        $data->setData(json_encode($event['content']['data']));
+        $data->setEventStreamId($event['content']['eventStreamId']);
+        $data->setMetadata(json_encode($this->safeGetMetadata($event)));
+        $data->setCreatedEpoch(strtotime($event['updated']) * 1000);
+
+        return new JsonEventRecord($data);
+    }
+
+    private function safeGetMetadata(array $event)
+    {
+        return $event['content']['metadata'] === '' ? [] : $event['content']['metadata'];
+    }
+}

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -2,18 +2,13 @@
 
 namespace DigitalRisks\LaravelEventStore\Console\Commands;
 
-use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
 use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
+use DigitalRisks\LaravelEventStore\Services\EventStoreEventService;
 use EventLoop\EventLoop;
 use Illuminate\Console\Command;
-use ReflectionClass;
-use ReflectionProperty;
-use Rxnet\EventStore\Data\EventRecord as EventData;
 use Rxnet\EventStore\EventStore;
 use Rxnet\EventStore\Record\AcknowledgeableEventRecord;
 use Rxnet\EventStore\Record\EventRecord;
-use Rxnet\EventStore\Record\JsonEventRecord;
-use TypeError;
 use Illuminate\Support\Facades\Event;
 
 class EventStoreWorkerThread extends Command
@@ -24,12 +19,15 @@ class EventStoreWorkerThread extends Command
 
     protected $description = 'Worker handling incoming event streams from ES';
 
+    private EventStoreEventService $eventService;
+
     private $loop;
 
-    public function __construct()
+    public function __construct(EventStoreEventService $eventService)
     {
         parent::__construct();
 
+        $this->eventService = $eventService;
         $this->loop = EventLoop::getLoop();
     }
 
@@ -104,83 +102,20 @@ class EventStoreWorkerThread extends Command
             }, 'report');
     }
 
-    protected function safeGetMetadata(EventRecord $event)
-    {
-        try {
-            return $event->getMetadata() ?? [];
-        } catch (TypeError $e) {
-            return [];
-        }
-    }
-
     public function dispatch(EventRecord $eventRecord): void
     {
-        $serializedEvent = $this->makeSerializableEvent($eventRecord);
+        $preparedEvent = $this->eventService->prepareEvent($eventRecord);
 
-        $type = $serializedEvent->getType();
-        $stream = $serializedEvent->getStreamId();
-        $number = $serializedEvent->getNumber();
-
-        if ($localEvent = $this->mapToLocalEvent($serializedEvent)) {
-            $event = $localEvent;
-            $payload = null;
-        } else {
-            $event = $type;
-            $payload = $serializedEvent;
-        }
-
+        // Custom
         $url = parse_url(config('eventstore.http_url'));
         $url = "{$url['scheme']}://{$url['host']}:{$url['port']}/web/index.html#";
 
+        $hasListener = Event::hasListeners($preparedEvent['type']);
+        $metadata = ['type' => $preparedEvent['type'], 'hasListeners' => $hasListener];
 
-        $hasListener = Event::hasListeners($type);
-        $metadata = ['type' => $type, 'hasListeners' => $hasListener];
+        (LaravelEventStore::$threadLogger)("{$url}/streams/{$preparedEvent['stream']}/{$preparedEvent['number']}", $metadata);
+        // End custom
 
-        (LaravelEventStore::$threadLogger)("{$url}/streams/{$stream}/{$number}", $metadata);
-        event($event, $payload);
-    }
-
-    private function makeSerializableEvent(EventRecord $event): JsonEventRecord
-    {
-        $data = new EventData();
-
-        $data->setEventId($event->getId());
-        $data->setEventType($event->getType());
-        $data->setEventNumber($event->getNumber());
-        $data->setData(json_encode($event->getData()));
-        $data->setEventStreamId($event->getStreamId());
-        $data->setMetadata(json_encode($this->safeGetMetadata($event)));
-        $data->setCreatedEpoch($event->getCreated()->getTimestamp() * 1000);
-
-        return new JsonEventRecord($data);
-    }
-
-    protected function mapToLocalEvent($event)
-    {
-        $eventToClass = LaravelEventStore::$eventToClass;
-        $className = $eventToClass ? $eventToClass($event) : 'App\Events\\' . $event->getType();
-
-        if (!class_exists($className)) {
-            return;
-        }
-
-        $reflection = new ReflectionClass($className);
-
-        if (!$reflection->implementsInterface(CouldBeReceived::class)) {
-            return;
-        }
-
-        $localEvent = new $className();
-        $props = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
-        $data = $event->getData();
-
-        foreach ($props as $prop) {
-            $key = $prop->getName();
-            $localEvent->$key = $data[$key] ?? null;
-        }
-
-        $localEvent->setEventRecord($event);
-
-        return $localEvent;
+        event($preparedEvent['event'], $preparedEvent['payload']);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace DigitalRisks\LaravelEventStore;
 
+use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreReplay;
 use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreReset;
 use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorker;
 use DigitalRisks\LaravelEventStore\Console\Commands\EventStoreWorkerThread;
@@ -27,6 +28,7 @@ class ServiceProvider extends LaravelServiceProvider
                 EventStoreWorker::class,
                 EventStoreWorkerThread::class,
                 EventStoreReset::class,
+                EventStoreReplay::class,
             ]);
         }
 

--- a/src/Services/EventStoreEventService.php
+++ b/src/Services/EventStoreEventService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Services;
+
+use DigitalRisks\LaravelEventStore\Contracts\CouldBeReceived;
+use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
+use ReflectionClass;
+use ReflectionProperty;
+use Rxnet\EventStore\Data\EventRecord as EventData;
+use Rxnet\EventStore\Record\EventRecord;
+use Rxnet\EventStore\Record\JsonEventRecord;
+use TypeError;
+
+class EventStoreEventService
+{
+    public function prepareEvent(EventRecord $eventRecord): array
+    {
+        $serializedEvent = $this->makeSerializableEvent($eventRecord);
+
+        $type = $serializedEvent->getType();
+        $stream = $serializedEvent->getStreamId();
+        $number = $serializedEvent->getNumber();
+
+        if ($localEvent = $this->mapToLocalEvent($serializedEvent)) {
+            $event = $localEvent;
+            $payload = null;
+        } else {
+            $event = $type;
+            $payload = $serializedEvent;
+        }
+
+        return [
+            'event' => $event,
+            'payload' => $payload,
+            'type' => $type,
+            'stream' => $stream,
+            'number' => $number
+        ];
+    }
+
+    private function makeSerializableEvent(EventRecord $event): JsonEventRecord
+    {
+        $data = new EventData();
+
+        $data->setEventId($event->getId());
+        $data->setEventType($event->getType());
+        $data->setEventNumber($event->getNumber());
+        $data->setData(json_encode($event->getData()));
+        $data->setEventStreamId($event->getStreamId());
+        $data->setMetadata(json_encode($this->safeGetMetadata($event)));
+        $data->setCreatedEpoch($event->getCreated()->getTimestamp() * 1000);
+
+        return new JsonEventRecord($data);
+    }
+
+    private function mapToLocalEvent($event)
+    {
+        $eventToClass = LaravelEventStore::$eventToClass;
+        $className = $eventToClass ? $eventToClass($event) : 'App\Events\\' . $event->getType();
+
+        if (!class_exists($className)) {
+            return;
+        }
+
+        $reflection = new ReflectionClass($className);
+
+        if (!$reflection->implementsInterface(CouldBeReceived::class)) {
+            return;
+        }
+
+        $localEvent = new $className();
+        $props = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
+        $data = $event->getData();
+
+        foreach ($props as $prop) {
+            $key = $prop->getName();
+            $localEvent->$key = $data[$key] ?? null;
+        }
+
+        $localEvent->setEventRecord($event);
+
+        return $localEvent;
+    }
+
+    private function safeGetMetadata(EventRecord $event)
+    {
+        try {
+            return $event->getMetadata() ?? [];
+        } catch (TypeError $e) {
+            return [];
+        }
+    }
+}

--- a/tests/ReplayTest.php
+++ b/tests/ReplayTest.php
@@ -2,7 +2,9 @@
 
 namespace DigitalRisks\LaravelEventStore\Tests;
 
+use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Facades\Event;
+use InvalidArgumentException;
 
 class ReplayTest extends TestCase
 {
@@ -38,5 +40,64 @@ class ReplayTest extends TestCase
         Event::assertDispatched('account.contact_details_added');
         Event::assertDispatched('account.ern_details_added');
         Event::assertDispatched('account.business_data_assigned');
+    }
+
+    public function test_it_throws_an_exeption_for_invalid_event()
+    {
+        // Arrange.
+        Event::fake();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Events only accepts integer values');
+
+        // Act.
+        $this->artisan('eventstore:replay', [
+            'stream' => 'accounts-v13',
+            'events' => 'foo',
+        ]);
+    }
+
+    public function test_it_throws_an_exeption_for_invalid_event_range()
+    {
+        // Arrange.
+        Event::fake();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Events only accepts integer values');
+
+        // Act.
+        $this->artisan('eventstore:replay', [
+            'stream' => 'accounts-v13',
+            'events' => '123-bar',
+        ]);
+    }
+
+    public function test_it_throws_an_exception_for_downward_event_range()
+    {
+        // Arrange.
+        Event::fake();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Events must be an upward range');
+
+        // Act.
+        $this->artisan('eventstore:replay', [
+            'stream' => 'accounts-v13',
+            'events' => '123-120',
+        ]);
+    }
+
+    public function test_it_throws_an_exception_if_event_not_found()
+    {
+        // Arrange.
+        Event::fake();
+
+        $this->expectException(ClientException::class);
+
+        // Act.
+        $this->artisan('eventstore:replay', [
+            'stream' => 'accounts-v13',
+            'events' => '99999999999',
+        ]);
     }
 }

--- a/tests/ReplayTest.php
+++ b/tests/ReplayTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Tests;
+
+use Illuminate\Support\Facades\Event;
+
+class ReplayTest extends TestCase
+{
+    public function test_it_can_replay_a_single_event()
+    {
+        // Arrange.
+        Event::fake();
+
+        // Act.
+        $this->artisan('eventstore:replay', [
+            'stream' => 'accounts-v13',
+            'events' => '41749',
+        ]);
+
+        // Assert.
+        Event::assertDispatched('account.opened');
+    }
+
+    public function test_it_can_replay_a_range_of_events_event()
+    {
+        // Arrange.
+        Event::fake();
+
+        // Act.
+        $this->artisan('eventstore:replay', [
+            'stream' => 'accounts-v13',
+            'events' => '41748-41753',
+        ]);
+
+        // Assert.
+        Event::assertDispatched('account.opened');
+        Event::assertDispatched('account.owner_assigned');
+        Event::assertDispatched('account.contact_details_added');
+        Event::assertDispatched('account.ern_details_added');
+        Event::assertDispatched('account.business_data_assigned');
+    }
+}


### PR DESCRIPTION
This PR will

Add a command eventstore:replay <stream> <event> that will replay the event from eventstore.

Supports a range of events by sending start-end events like
php artisan eventstore:replay accounts-v13 390-400

@eithed @morrislaptop Github refused to pull in latest commits to previous PR
https://github.com/gosuperscript/laravel-eventstore/pull/30

Added extra tests and exceptions
Moved duplicate code into service class