### PR TITLE
Introduce `ConnectionLostException`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor
 composer.lock
+.idea
 .phpunit.result.cache
 build
 .env

--- a/src/Console/Commands/EventStoreWorkerThread.php
+++ b/src/Console/Commands/EventStoreWorkerThread.php
@@ -3,6 +3,7 @@
 namespace DigitalRisks\LaravelEventStore\Console\Commands;
 
 use DigitalRisks\LaravelEventStore\EventStore as LaravelEventStore;
+use DigitalRisks\LaravelEventStore\Exceptions\ConnectionLostException;
 use DigitalRisks\LaravelEventStore\Services\EventStoreEventService;
 use EventLoop\EventLoop;
 use Illuminate\Console\Command;
@@ -46,7 +47,7 @@ class EventStoreWorkerThread extends Command
             report($e);
         }
 
-        report(new \Exception('Lost connection with EventStore - reconnecting'));
+        report(new ConnectionLostException());
         sleep(1);
 
         $this->handle();

--- a/src/Exceptions/ConnectionLostException.php
+++ b/src/Exceptions/ConnectionLostException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DigitalRisks\LaravelEventStore\Exceptions;
+
+use Exception;
+
+class ConnectionLostException extends Exception
+{
+    public function __construct($message = 'Lost connection with EventStore - reconnecting', $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}


### PR DESCRIPTION
Having a dedicated exception, allows to to configure reporting in Laravel's error handler.